### PR TITLE
corrigindo logica do MHS para testes passarem

### DIFF
--- a/src/main/scala/br/unb/cic/tp1/mh/ast/ExpAplicacaoLambda.scala
+++ b/src/main/scala/br/unb/cic/tp1/mh/ast/ExpAplicacaoLambda.scala
@@ -7,11 +7,8 @@ import br.unb.cic.tp1.exceptions.ExpressaoInvalida
 case class ExpAplicacaoLambda(exp1 : Expressao, exp2 : Expressao) extends Expressao { 
 
   override def avaliar(): Valor = {
-    //println("- exp1: " + exp1)
+    
     val v1 = exp1.avaliar()
-
-    //println("- ambiente atual: " + Ambiente.ambienteAtual())
-    //println("- Ambiente closure: " + v1.asInstanceOf[Closure].ambiente)
 
     v1 match {
       case Closure(v, c, ambiente) => {
@@ -24,6 +21,16 @@ case class ExpAplicacaoLambda(exp1 : Expressao, exp2 : Expressao) extends Expres
       
       case _             => throw ExpressaoInvalida()
     } 
+  }
+
+  override def verificaTipo(): Tipo = {
+    val t1 = exp1.verificaTipo()
+    val t2 = exp2.verificaTipo()
+
+    if( t1.isInstanceOf[TInt] && t2.isInstanceOf[TInt] ) {
+      return TInt()
+    }
+    return TErro()
   }
   
 }

--- a/src/main/scala/br/unb/cic/tp1/mh/ast/ExpAplicacaoNomeada.scala
+++ b/src/main/scala/br/unb/cic/tp1/mh/ast/ExpAplicacaoNomeada.scala
@@ -16,4 +16,8 @@ class ExpAplicacaoNomeada(val nome: String, argumentoAtual : Expressao) extends 
 
     return res
   }
+
+  override def verificaTipo(): Tipo = {
+    return argumentoAtual.verificaTipo()
+  }
 }

--- a/src/main/scala/br/unb/cic/tp1/mh/ast/ExpLet.scala
+++ b/src/main/scala/br/unb/cic/tp1/mh/ast/ExpLet.scala
@@ -1,6 +1,6 @@
 package br.unb.cic.tp1.mh.ast
 
-import br.unb.cic.tp1.mh.memoria.Ambiente
+import br.unb.cic.tp1.mh.memoria._
 
 class ExpLet(val id : String, val expNomeada : Expressao, val corpo : Expressao) extends Expressao {
 
@@ -8,5 +8,9 @@ class ExpLet(val id : String, val expNomeada : Expressao, val corpo : Expressao)
     val valor = expNomeada.avaliar() // innermost strategy
     Ambiente.atualiza(id, valor)
     return corpo.avaliar()
+  }
+
+  override def verificaTipo(): Tipo = {
+    return corpo.verificaTipo()
   }
 }

--- a/src/main/scala/br/unb/cic/tp1/mh/ast/ExpLet.scala
+++ b/src/main/scala/br/unb/cic/tp1/mh/ast/ExpLet.scala
@@ -4,10 +4,11 @@ import br.unb.cic.tp1.mh.memoria._
 
 class ExpLet(val id : String, val expNomeada : Expressao, val corpo : Expressao) extends Expressao {
 
+  Gama.salvar( id, expNomeada.verificaTipo() )
+
   override def avaliar(): Valor = {
     val valor = expNomeada.avaliar() // innermost strategy
     Ambiente.atualiza(id, valor)
-    Gama.salvar( id, expNomeada.verificaTipo() )
     return corpo.avaliar()
   }
 

--- a/src/main/scala/br/unb/cic/tp1/mh/ast/ExpLet.scala
+++ b/src/main/scala/br/unb/cic/tp1/mh/ast/ExpLet.scala
@@ -7,6 +7,7 @@ class ExpLet(val id : String, val expNomeada : Expressao, val corpo : Expressao)
   override def avaliar(): Valor = {
     val valor = expNomeada.avaliar() // innermost strategy
     Ambiente.atualiza(id, valor)
+    Gama.salvar( id, expNomeada.verificaTipo() )
     return corpo.avaliar()
   }
 

--- a/src/main/scala/br/unb/cic/tp1/mh/ast/ExpRef.scala
+++ b/src/main/scala/br/unb/cic/tp1/mh/ast/ExpRef.scala
@@ -1,6 +1,6 @@
 package br.unb.cic.tp1.mh.ast
 
-import br.unb.cic.tp1.mh.memoria.Ambiente
+import br.unb.cic.tp1.mh.memoria._
 
 import br.unb.cic.tp1.exceptions.VariavelNaoDeclaradaException
 
@@ -14,5 +14,9 @@ case class ExpRef(variavel : String) extends Expressao {
       case ex: NoSuchElementException => throw VariavelNaoDeclaradaException()
     }
   } 
+
+  override def verificaTipo(): Tipo = {
+    Gama.encontrar( variavel ) 
+  }
 
 }

--- a/src/main/scala/br/unb/cic/tp1/mh/ast/ExpSoma.scala
+++ b/src/main/scala/br/unb/cic/tp1/mh/ast/ExpSoma.scala
@@ -13,7 +13,7 @@ case class ExpSoma(lhs : Expressao, rhs : Expressao) extends Expressao {
     val t1 = lhs.verificaTipo
     val t2 = rhs.verificaTipo
 
-    if(t1 == TInt && t2 == TInt) {
+    if( t1.isInstanceOf[TInt] && t2.isInstanceOf[TInt] ) {
       return TInt()
     }
     return TErro()

--- a/src/main/scala/br/unb/cic/tp1/mh/ast/Expressao.scala
+++ b/src/main/scala/br/unb/cic/tp1/mh/ast/Expressao.scala
@@ -10,6 +10,6 @@ case class TArr(val t1: Tipo, val t2: Tipo) extends Tipo
 
 trait Expressao {
   def avaliar() : Valor
-  def verificaTipo : Tipo
+  def verificaTipo() : Tipo
 }
 

--- a/src/main/scala/br/unb/cic/tp1/mh/ast/Valor.scala
+++ b/src/main/scala/br/unb/cic/tp1/mh/ast/Valor.scala
@@ -10,4 +10,7 @@ abstract class ValorConcreto[T](val valor : T) extends Valor {
 
 case class Closure(id : String, corpo : Expressao, ambiente : mutable.HashMap[String, Valor]) extends Valor {
    override def avaliar(): Valor = this
+   override def verificaTipo(): Tipo = {
+     corpo.verificaTipo()
+   }
 }

--- a/src/main/scala/br/unb/cic/tp1/mh/memoria/Gama.scala
+++ b/src/main/scala/br/unb/cic/tp1/mh/memoria/Gama.scala
@@ -12,7 +12,7 @@ object Gama {
   }
 
   def salvar( simbolo: String, tipo: Tipo ): Unit = {
-    symbolTable( simbolo ) = tipo
+    symbolTable += (simbolo -> tipo)
   }
 
 }

--- a/src/main/scala/br/unb/cic/tp1/mh/memoria/Gama.scala
+++ b/src/main/scala/br/unb/cic/tp1/mh/memoria/Gama.scala
@@ -1,0 +1,18 @@
+package br.unb.cic.tp1.mh.memoria
+
+import br.unb.cic.tp1.mh.ast._
+import scala.collection.mutable
+
+object Gama {
+
+  private val symbolTable = new mutable.HashMap[String, Tipo]
+
+  def encontrar( simbolo: String ): Tipo = {
+    symbolTable(simbolo)
+  }
+
+  def salvar( simbolo: String, tipo: Tipo ): Unit = {
+    symbolTable( simbolo ) = tipo
+  }
+
+}

--- a/src/test/scala/br/unb/cic/tp1/mh/ast/TesteAplicacaoLambda.scala
+++ b/src/test/scala/br/unb/cic/tp1/mh/ast/TesteAplicacaoLambda.scala
@@ -9,7 +9,7 @@ class TesteAplicacaoLambda extends FlatSpec with Matchers {
   
   it should "be evaluated to Valor(6) when ((x) -> x + 1) 5)" in {
     Ambiente.iniciar()
-    val inc = new ExpLambda("x", new ExpSoma(new ExpRef("x"), ValorInteiro(1)))
+    val inc = new ExpLambda("x", TInt(),new ExpSoma(new ExpRef("x"), ValorInteiro(1)))
     val app = new ExpAplicacaoLambda(inc, ValorInteiro(5)) 
 
     app.avaliar() should be (ValorInteiro(6))
@@ -18,7 +18,7 @@ class TesteAplicacaoLambda extends FlatSpec with Matchers {
   ignore should "be evaluated to 20 when let y = 10 in let f = (x -> x +y) in let y = 20 in f 10" in {
     Ambiente.iniciar()
     val let1 = new ExpLet("y", ValorInteiro(20), ExpAplicacaoLambda(ExpRef("f"), ValorInteiro(10)))
-    val let2 = new ExpLet("f", new ExpLambda("x", new ExpSoma(ExpRef("x"), ExpRef("y"))), let1)
+    val let2 = new ExpLet("f", new ExpLambda("x", TInt(), new ExpSoma(ExpRef("x"), ExpRef("y"))), let1)
     val let3 = new ExpLet("y", ValorInteiro(10), let2)
 
     let3.avaliar() should be (ValorInteiro(20))

--- a/src/test/scala/br/unb/cic/tp1/mh/ast/TesteExpLambda.scala
+++ b/src/test/scala/br/unb/cic/tp1/mh/ast/TesteExpLambda.scala
@@ -9,7 +9,7 @@ class TesteExpLambda extends FlatSpec with Matchers {
   behavior of "a lambda expression"
   
   it should "be evaluated to Closure(x, x+1) when (x) -> x + 1" in {
-    val inc  = new ExpLambda("x", 
+    val inc  = new ExpLambda("x", TInt(),
       new ExpSoma(new ExpRef("x"), ValorInteiro(1)))
 
 

--- a/src/test/scala/br/unb/cic/tp1/mh/ast/TesteExpLet.scala
+++ b/src/test/scala/br/unb/cic/tp1/mh/ast/TesteExpLet.scala
@@ -7,6 +7,24 @@ import br.unb.cic.tp1.mh.memoria.Ambiente
 class TesteExpLet extends FlatSpec with Matchers {
 
   behavior of "a let expression"
+
+  it should "return body type if tying is correct" in {
+    Ambiente.iniciar()
+    // let x = true in x + x
+    val let = new ExpLet("x", ValorInteiro(10),
+      new ExpSoma(new ExpRef("x"), new ExpRef("x")))
+
+    let.verificaTipo() shouldBe a [TInt]
+  }
+
+  it should "return error of typing" in {
+    Ambiente.iniciar()
+    // let x = true in x + x
+    val let = new ExpLet("x", ValorBooleano(true),
+      new ExpSoma(new ExpRef("x"), new ExpRef("x")))
+
+    let.verificaTipo() shouldBe a [TErro]
+  }
   
   it should "be evaluated to Valor(20) when let x = 10 in x + x" in {
     Ambiente.iniciar()


### PR DESCRIPTION
1. adicionei o método `verificaTipo` das classes concretas que implementam `Expressao`;
2. adicionei o parâmetro `tipoArgumento` nos testes que incluem `ExpLambda`;
3. troquei `t1 == TInt` para ` t1.isInstanceOf[TInt]`
4. criei a classe `Gama` com os métodos `salvar( simbolo: String, tipo: Tipo )`e  `encontrar( simbolo: String )`.
5. salvando tipo de `ExpLet` em `Gama` no construtor

Agora os testes estão passando 😄 